### PR TITLE
DNS CenTrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 *Are you using `CenTrace`? If so, let us know! Shoot us an email at censoredplanet@umich.edu.*
 
-`CenTrace` is a general-purpose application-layer censorship traceroute tool, that sends TTL-limited HTTP and TLS packets to detect the network locations of censorship devices. `CenTrace` can perform requests to different endpoints parallely using specified domains. It first tests to see whether there is any sign of interference for a particular measurement, by comparing responses with a control measurement. If there is an indication of blocking, it then performs multiple repetitions of two traceroutes to the endpoint - one with the test domain and the other with a control domain- to determine the network path to the endpoint, and the exact location of the blocking. `CenTrace` has the following features:
+`CenTrace` is a general-purpose application-layer censorship traceroute tool, that sends TTL-limited HTTP, TLS, and DNS packets to detect the network locations of censorship devices. `CenTrace` can perform requests to different endpoints parallely using specified domains. It first tests to see whether there is any sign of interference for a particular measurement, by comparing responses with a control measurement. If there is an indication of blocking, it then performs multiple repetitions of two traceroutes to the endpoint - one with the test domain and the other with a control domain- to determine the network path to the endpoint, and the exact location of the blocking. `CenTrace` has the following features:
 1.  It can detect censorship devices that inject packets (such as a TCP RST packet or a blockpage) as well as devices that drop packets (and induce a timeout).
 2.  `CenTrace` can differentiate between in-path (processing packets at line rate) and on-path (receiving only a copy of the packets) devices.  
 3.  `CenTrace` accounts for stateful blocking by including a customizable delay between successive traceroutes and measurements. 
@@ -31,7 +31,7 @@ The following flags can be provided for running measurements:
 | censored_keyword       | `example.com`            | Domain to include in control measurements              | `example.com`                              |
 | server_ip              | Required if no filename  | IP of endpoint to send measurements to                 | `1.1.1.1`                                  |
 | verbose                | False                    | Print debug output                                     |                                            |
-| https                  | False                    | Send HTTP (false) or TLS (true) measurements           |                                            |
+| application_protocol                  | http                    | Send HTTP (http), TLS (https) or DNS (dns) measurements           |                                            |
 | iprr                   | False                    | Try including IP record route option if true           |                                            |
 | tracebox               | False                    | Run a Tracebox measurement additionally (requires [Tracebox](http://www.tracebox.org/) to be installed) |                                            |
 | interface              | Picked by default        | Interface to send measurements from                    |                                            |
@@ -48,7 +48,7 @@ The following flags can be provided for running measurements:
 | routeviews_file        | Required                 | Data from Routeviews to get ASN information            |                                            |
 | asnames_file           | Required                 | AS Number to Name mapping from [`pyasn`](https://github.com/hadiasghari/pyasn/blob/master/pyasn-utils/pyasn_util_asnames.py)                 |                                            |
 
-The following flags can be provided for analyzing pcaps:
+The following flags can be provided for analyzing pcaps (currently only available for TCP):
 
 |         Flag           |          Default         |                       Function                         |           Example             |
 | ---------------------- | ------------------------ | ------------------------------------------------------ | ----------------------------- |
@@ -67,7 +67,7 @@ The following flags can be provided for analyzing pcaps:
 The `CenTrace` tool provides two functions:
 1. Run traceroute measurements across a list of endpoints: 
 ```
-sudo python3 traceroute.py --filename examples/input.csv -o examples/output.csv -v -l examples/log.txt --iprr --comparequoted -r 5 -R 120 -p -pd examples/pcaps -m 2 -i enp1s0f1 -rv routeviews_file -an asnames_file --https -cr 2 -mi 3
+sudo python3 traceroute.py --filename examples/input.csv -o examples/output.csv -v -l examples/log.txt --iprr --comparequoted -r 5 -R 120 -p -pd examples/pcaps -m 2 -i enp1s0f1 -rv routeviews_file -an asnames_file --application_protocol https -cr 2 -mi 3
 ```
 2. Analyze pcaps:
  ```

--- a/traceroute.py
+++ b/traceroute.py
@@ -488,7 +488,6 @@ def is_ip_alive(server_ip, dport, uncensored_keyword, interface=None,retries=3):
         if dport in TCP_PORTS.values():
             tcp_conn = tcp.TCPSession(server_ip, dport)
             if not tcp_conn.handshake():
-                verbose_output += "No handshake\n"
                 continue
             if tcp_conn.close():
                 alive = True

--- a/udp.py
+++ b/udp.py
@@ -1,0 +1,68 @@
+from operator import truediv
+from socket import timeout
+from scapy.all import *
+
+UDP_IN_ICMP = "UDP in ICMP"
+
+class UDPSession(object):
+    def __init__(self, ip, dport, max_ttl=64, timeout=3, sport=None, interface=None):
+        self.ip = ip
+        self.dport = dport
+        self.sport = sport
+        self._max_ttl = max_ttl
+        self._timeout = timeout
+        self._interface = interface
+        if interface == "any":
+            self._interface = None
+        ip_id = random.randint(1, 65500)
+        if self.sport is None:
+            self.sport = random.randint(49152, 65535)
+        self.ip_pkt = IP(dst = self.ip, id = ip_id, flags = 'DF', ttl=self._max_ttl)
+    
+    #Calling this a handshake, but it's not really
+    def handshake(self, hostname):
+        self.ip_pkt.id = self.ip_pkt.id + 1
+        self.ip_pkt.ttl = self._max_ttl
+        del self.ip_pkt.chksum
+        req = self.ip_pkt / UDP(dport=self.dport, sport=self.sport) / DNS(rd=1, qd=DNSQR(qname=hostname))
+
+        answer = sr1(req, verbose=False, timeout=self._timeout)
+        if answer is not None:
+            return True
+        return False
+
+    def set_iprr(self):
+        ip_record_route_option = IPOption_RR(copy_flag=0, length=39, routers=['0.0.0.0'] * 9)
+        self.ip_pkt.options.append(ip_record_route_option)
+    
+    def iph_length(self):
+        """ Returns IP header length in bytes. """
+        p = self.ip_pkt.__class__(bytes(self.ip_pkt))
+        return p[IP].ihl * 4
+    
+
+    def sendrecv(self, data, ttl, retries=3):
+        """ Sends `data` payload and returns responses. """
+        self.ip_pkt.id = self.ip_pkt.id + 1
+        self.ip_pkt.ttl = ttl
+        del self.ip_pkt.chksum
+        req = self.ip_pkt / UDP(dport=self.dport, sport=self.sport) / data
+
+        responses = []
+        for _ in range(retries):
+            # This filter checks for ICMP time exceeded packets or any other packets destined for the session source port.
+            # TODO: We don't want to recv() ICMP Time Exceeded packets that are not direct responses to this probe.
+            s = AsyncSniffer(filter=f"icmp[0] == 11 or (port {self.sport} and not dst host {self.ip})")
+            s.start()
+            time.sleep(0.1)
+            send(req, verbose=False)
+            time.sleep(self._timeout)
+            responses = s.stop()
+            if responses is not None:
+                break
+        direct_responses = []
+        for packet in responses:
+            if packet.haslayer(ICMP) and packet.haslayer(UDP_IN_ICMP) and packet[UDP_IN_ICMP].sport != self.sport:
+                continue
+            direct_responses.append(packet)
+        return req, direct_responses


### PR DESCRIPTION
Adding an UDP module to send DNS CenTrace measurements on Port 53. Currently, only makign measurements are supported, analysis needs to be refactored to consider and parse DNS responses. 